### PR TITLE
Smaller hit box, plus bug fixes

### DIFF
--- a/Zelduino/game.c
+++ b/Zelduino/game.c
@@ -15,10 +15,10 @@ void zGame_Init()
   zGame.playerHitBox.x = ( ( WORLD_TILES_X / 2 ) - 3 ) * WORLD_TILE_SIZE;
   zGame.playerHitBox.y = ( WORLD_TILES_Y / 2 ) * WORLD_TILE_SIZE;
   zGame.playerHitBox.w = 12;
-  zGame.playerHitBox.h = 12;
+  zGame.playerHitBox.h = 8;
 
   zGame.playerSpriteOffset.x = -2;
-  zGame.playerSpriteOffset.y = -2;
+  zGame.playerSpriteOffset.y = -6;
 
   zGame.playerVelocity.x = 0;
   zGame.playerVelocity.y = 0;

--- a/Zelduino/lcd_screen.c
+++ b/Zelduino/lcd_screen.c
@@ -196,6 +196,8 @@ void zLcdScreen_DrawPlayerSprite( int16_t x, int16_t y )
         writeData16( zGame.palette[texturePair >> 4] );
       }
 
+      xOffset++;
+
       if ( zGame.palette[texturePair & 0xF] == TRANSPARENT_COLOR )
       {
         uint16_t rearPixel = zLcdScreen_GetWorldPixelColor( x + xOffset, y + yOffset );
@@ -416,16 +418,13 @@ static uint16_t zLcdScreen_GetWorldPixelColor( int16_t x, int16_t y )
   int16_t worldX = x - zRenderer.worldScreenOffset.x;
   int16_t worldY = y - zRenderer.worldScreenOffset.y;
 
-  zWorldTile_t* tile = &( zGame.worldTiles[( ( worldY / WORLD_TILE_SIZE ) * WORLD_TILES_X ) + ( worldX / WORLD_TILE_SIZE )] );
+  uint8_t textureIndex = zGame.worldTiles[( ( worldY / WORLD_TILE_SIZE ) * WORLD_TILES_X ) + ( worldX / WORLD_TILE_SIZE )].textureIndex;
+  uint8_t textureStartX = textureIndex * ( WORLD_TILE_SIZE / 2 );
+  uint8_t pixelX = worldX % WORLD_TILE_SIZE;
+  uint8_t pixelY = worldY % WORLD_TILE_SIZE;
+  uint16_t textureMapIndex = ( pixelY * ( ( WORLD_TILE_SIZE / 2 ) * WORLD_TILE_TEXTURES ) ) + ( textureStartX + ( pixelX / 2 ) );
 
-  uint8_t textureMapX = tile->textureIndex * ( WORLD_TILE_SIZE / 2 );
-
-  uint8_t textureOffsetX = worldX % WORLD_TILE_SIZE;
-  uint8_t textureOffsetY = worldY % WORLD_TILE_SIZE;
-
-  uint16_t textureMapIndex = ( textureOffsetY * ( ( WORLD_TILE_SIZE / 2 ) * WORLD_TILE_TEXTURES ) ) + ( textureMapX + ( textureOffsetX / 2 ) );
-
-  if ( textureOffsetX % 2 == 0 )
+  if ( pixelX % 2 == 0 )
   {
     return zGame.palette[zGame.worldTextureMap[textureMapIndex] >> 4];
   }

--- a/Zelduino/lcd_screen.c
+++ b/Zelduino/lcd_screen.c
@@ -186,7 +186,14 @@ void zLcdScreen_DrawPlayerSprite( int16_t x, int16_t y )
     {
       uint8_t texturePair = zGame.playerTextureMap[( row * ( ( PLAYER_SPRITE_SIZE / 2 ) * PLAYER_SPRITE_FRAMES ) ) + col];
 
-      if ( zGame.palette[texturePair >> 4] == TRANSPARENT_COLOR)
+      if ( x + xOffset - zRenderer.worldScreenOffset.x < 0 ||
+           y + yOffset - zRenderer.worldScreenOffset.y < 0 ||
+           x + xOffset - zRenderer.worldScreenOffset.x >= ( WORLD_TILES_X * WORLD_TILE_SIZE ) ||
+           y + yOffset - zRenderer.worldScreenOffset.y >= ( WORLD_TILES_Y * WORLD_TILE_SIZE ) )
+      {
+        writeData16( 0 );
+      }
+      else if ( zGame.palette[texturePair >> 4] == TRANSPARENT_COLOR)
       {
         uint16_t rearPixel = zLcdScreen_GetWorldPixelColor( x + xOffset, y + yOffset );
         writeData16( rearPixel );
@@ -198,7 +205,14 @@ void zLcdScreen_DrawPlayerSprite( int16_t x, int16_t y )
 
       xOffset++;
 
-      if ( zGame.palette[texturePair & 0xF] == TRANSPARENT_COLOR )
+      if ( x + xOffset - zRenderer.worldScreenOffset.x < 0 ||
+           y + yOffset - zRenderer.worldScreenOffset.y < 0 ||
+           x + xOffset - zRenderer.worldScreenOffset.x >= ( WORLD_TILES_X * WORLD_TILE_SIZE ) ||
+           y + yOffset - zRenderer.worldScreenOffset.y >= ( WORLD_TILES_Y * WORLD_TILE_SIZE ) )
+      {
+        writeData16( 0 );
+      }
+      else if ( zGame.palette[texturePair & 0xF] == TRANSPARENT_COLOR )
       {
         uint16_t rearPixel = zLcdScreen_GetWorldPixelColor( x + xOffset, y + yOffset );
         writeData16( rearPixel );


### PR DESCRIPTION
## Overview

This does three things:

1) The hit box is now smaller, and the player sprite offset is set up so we get that isometric effect when colliding with upper tiles.
2) Fixed a bug with transparent pixels. Once again, the bit-packing has caused problems, we were indexing too far to the right.
3) Any section of a sprite that's outside of the world boundaries is drawn black.